### PR TITLE
Potential fix for code scanning alert no. 29: Database query built from user-controlled sources

### DIFF
--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -223,8 +223,12 @@ export const resetPassword = async (req, res) => {
   const { token } = req.query;
   const { password } = req.body;
 
+  if (typeof token !== "string") {
+    return res.status(400).json({ message: "Invalid token" });
+  }
+
   try {
-    const user = await User.findOne({ resetToken: token, resetTokenExpiration: { $gt: Date.now() } });
+    const user = await User.findOne({ resetToken: { $eq: token }, resetTokenExpiration: { $gt: Date.now() } });
     if (!user) {
       return res.status(400).json({ message: "Invalid or expired token" });
     }


### PR DESCRIPTION
Potential fix for [https://github.com/mariokreitz/auth-api-test/security/code-scanning/29](https://github.com/mariokreitz/auth-api-test/security/code-scanning/29)

To fix the problem, we need to ensure that the `token` is treated as a literal value in the MongoDB query. This can be achieved by using the `$eq` operator to ensure that the user input is interpreted as a literal value and not as a query object. Additionally, we should validate the `token` to ensure it is a string before using it in the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
