### PR TITLE
Potential fix for code scanning alert no. 28: Database query built from user-controlled sources

### DIFF
--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -180,7 +180,7 @@ export const requestPasswordReset = async (req, res) => {
   const { email } = req.body;
 
   try {
-    const user = await User.findOne({ email });
+    const user = await User.findOne({ email: { $eq: email } });
     if (!user) {
       return res.status(400).json({ message: "No user found with this email address" });
     }


### PR DESCRIPTION
Potential fix for [https://github.com/mariokreitz/auth-api-test/security/code-scanning/28](https://github.com/mariokreitz/auth-api-test/security/code-scanning/28)

To fix the problem, we need to ensure that the `email` parameter is treated as a literal value in the MongoDB query. This can be achieved by using the `$eq` operator in the query. This will ensure that the user input is interpreted as a literal value and not as a query object.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
