### PR TITLE
Potential fix for code scanning alert no. 15: Missing CSRF middleware

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "nodemailer": "^6.9.16",
     "passport": "^0.7.0",
     "passport-github2": "^0.1.12",
-    "winston": "^3.17.0"
+    "winston": "^3.17.0",
+    "lusca": "^1.7.0"
   },
   "devDependencies": {
     "nodemon": "^3.1.9"

--- a/src/app.js
+++ b/src/app.js
@@ -2,6 +2,7 @@ import express from "express";
 import helmet from "helmet";
 import cors from "cors";
 import cookieParser from "cookie-parser";
+import lusca from "lusca";
 import authRoutes from "./routes/auth.routes.js";
 import userRoutes from "./routes/user.routes.js";
 import adminRoutes from "./routes/admin.routes.js";
@@ -22,6 +23,7 @@ app.use(
 app.use(express.json());
 app.use(express.urlencoded({ extended: true }));
 app.use(cookieParser());
+app.use(lusca.csrf());
 app.use(requestLogger);
 app.use(errorHandler);
 


### PR DESCRIPTION
Potential fix for [https://github.com/mariokreitz/auth-api-test/security/code-scanning/15](https://github.com/mariokreitz/auth-api-test/security/code-scanning/15)

To fix the problem, we need to add CSRF protection middleware to the application. The `lusca` package provides a CSRF middleware that can be easily integrated into the Express application. We will install the `lusca` package and then use its CSRF middleware in the application.

1. Install the `lusca` package.
2. Import the `lusca` package in the `src/app.js` file.
3. Add the `lusca.csrf()` middleware to the application before the route definitions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
