### PR TITLE
Potential fix for code scanning alert no. 26: Database query built from user-controlled sources

### DIFF
--- a/src/controllers/user.controller.js
+++ b/src/controllers/user.controller.js
@@ -103,8 +103,11 @@ export const updateProfilePicture = async (req, res) => {
   try {
     const userId = req.user.userId;
     const { profilePicture } = req.body;
+    if (typeof profilePicture !== "string") {
+      return res.status(400).json({ message: "Invalid profile picture format" });
+    }
 
-    const updatedUser = await User.findByIdAndUpdate(userId, { profilePicture }, { new: true, runValidators: true }).select(
+    const updatedUser = await User.findByIdAndUpdate(userId, { $set: { profilePicture } }, { new: true, runValidators: true }).select(
       "-password -verificationToken -resetToken -resetTokenExpiration"
     );
 


### PR DESCRIPTION
Potential fix for [https://github.com/mariokreitz/auth-api-test/security/code-scanning/26](https://github.com/mariokreitz/auth-api-test/security/code-scanning/26)

To fix the problem, we need to ensure that the `profilePicture` value is treated as a literal value and not as a query object. This can be achieved by using the `$set` operator in the MongoDB query to explicitly set the `profilePicture` field. Additionally, we should validate that the `profilePicture` is a string before using it in the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
