### PR TITLE
Potential fix for code scanning alert no. 25: Database query built from user-controlled sources

### DIFF
--- a/src/controllers/admin.controller.js
+++ b/src/controllers/admin.controller.js
@@ -145,8 +145,12 @@ export const updateUser = async (req, res) => {
 export const deleteUser = async (req, res) => {
   const { userId } = req.body;
 
+  if (typeof userId !== "string") {
+    return res.status(400).json({ message: "Invalid user ID" });
+  }
+
   try {
-    const user = await User.findByIdAndDelete(userId);
+    const user = await User.findByIdAndDelete({ _id: { $eq: userId } });
     if (!user) {
       return res.status(404).json({ message: "User not found" });
     }


### PR DESCRIPTION
Potential fix for [https://github.com/mariokreitz/auth-api-test/security/code-scanning/25](https://github.com/mariokreitz/auth-api-test/security/code-scanning/25)

To fix the problem, we need to ensure that the `userId` is treated as a literal value and not as a query object. This can be achieved by using MongoDB's `$eq` operator to ensure that the user input is interpreted correctly. Additionally, we should validate the `userId` to ensure it is a valid string before using it in the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
