### PR TITLE
Potential fix for code scanning alert no. 22: Database query built from user-controlled sources

### DIFF
--- a/src/controllers/auth.controller.js
+++ b/src/controllers/auth.controller.js
@@ -81,7 +81,7 @@ export const login = async (req, res) => {
   const { email, password } = req.body;
 
   try {
-    const user = await User.findOne({ email });
+    const user = await User.findOne({ email: { $eq: email } });
     if (!user) {
       return res.status(400).json({ message: "Invalid credentials" });
     }


### PR DESCRIPTION
Potential fix for [https://github.com/mariokreitz/auth-api-test/security/code-scanning/22](https://github.com/mariokreitz/auth-api-test/security/code-scanning/22)

To fix the problem, we need to ensure that the user input is properly sanitized before being used in the database query. For MongoDB, we can use the `$eq` operator to ensure that the user input is treated as a literal value. This prevents any potential NoSQL injection attacks.

We will modify the query on line 84 to use the `$eq` operator for the `email` field. This change will ensure that the `email` parameter is interpreted as a literal value and not as a query object.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
