### PR TITLE
Potential fix for code scanning alert no. 17: Database query built from user-controlled sources

### DIFF
--- a/src/controllers/audit.controller.js
+++ b/src/controllers/audit.controller.js
@@ -44,7 +44,7 @@ export const getAuditLogs = async (req, res) => {
 
     const query = {};
     if (user) query.user = { $eq: user };
-    if (action) query.action = action;
+    if (action) query.action = { $eq: action };
     if (startDate || endDate) {
       query.timestamp = {};
       if (startDate) query.timestamp.$gte = new Date(startDate);


### PR DESCRIPTION
Potential fix for [https://github.com/mariokreitz/auth-api-test/security/code-scanning/17](https://github.com/mariokreitz/auth-api-test/security/code-scanning/17)

To fix the problem, we need to ensure that the `action` parameter is treated as a literal value and not as a query object. This can be achieved by using the `$eq` operator for the `action` parameter, similar to how the `user` parameter is handled. This will ensure that the `action` parameter is interpreted as a literal value and not as a query object.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
